### PR TITLE
Fix: 로그인 하지 않았을 경우 선수 맛집 리스트 조회 안되는 문제 해결

### DIFF
--- a/src/main/java/_4/TourismContest/spot/application/SpotService.java
+++ b/src/main/java/_4/TourismContest/spot/application/SpotService.java
@@ -82,8 +82,11 @@ public class SpotService {
         List<AthletePickSpot> athletePickSpotsInfo = athletePickSpotRepository.findAthletePickSpotsBySpotIn(spotsByStadiumAndCategory);
         List<SpotBasicPreviewDto> athletePickPreviewDtoList = new ArrayList<>();
         for (AthletePickSpot info : athletePickSpotsInfo) {
-            Optional<SpotScrap> scrap = spotScrapRepository.findByUserIdAndSpotContentId(userPrincipal.getId(), info.getSpot().getId());
-            boolean isScraped = scrap.isPresent();
+            boolean isScraped = false;
+            if(userPrincipal != null){
+                Optional<SpotScrap> scrap = spotScrapRepository.findByUserIdAndSpotContentId(userPrincipal.getId(), info.getSpot().getId());
+                isScraped = scrap.isPresent();
+            }
 
             athletePickPreviewDtoList.add(SpotAthletePickPreviewDto.of(info, isScraped));
         }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
Feat : ~
-->

##  📌 관련 이슈

- closed: #199

## ✨ PR 세부 내용
로그인 하지 않았을 경우 선수 맛집 리스트 조회 안되는 문제 해결
<!-- 수정/추가한 내용을 적어주세요. -->

## ⌛ 소요 시간
