### PR TITLE
Fix: 1시간 단위 날씨 반환 API -> 경기 시작 1시간전부터 그날 23시 까지 데이터 반환하도록 수정

### DIFF
--- a/src/main/java/_4/TourismContest/weather/application/WeatherForecastService.java
+++ b/src/main/java/_4/TourismContest/weather/application/WeatherForecastService.java
@@ -78,16 +78,18 @@ public class WeatherForecastService {
                 .orElseThrow(() -> new IllegalArgumentException("Illegal Baseball ID"));
 
         LocalDateTime gameTime = game.getTime().minusHours(1L);
+        LocalDateTime endOfDay = game.getTime().toLocalDate().atTime(LocalTime.MAX);
 
         Stadium stadium = stadiumRepository.findTopByName(game.getLocation())
                 .orElseThrow(() -> new IllegalArgumentException("Illegal Stadium Name"));
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<WeatherForecast> weatherForecastPage = weatherForecastRepository.findByNxAndNyAndCategoryAndFcstTimeIsAfter(
+        Page<WeatherForecast> weatherForecastPage = weatherForecastRepository.findByNxAndNyAndCategoryAndFcstTimeBetween(
                 stadium.getNx(),
                 stadium.getNy(),
                 "SKY",
                 gameTime,
+                endOfDay,
                 pageable
         );
 

--- a/src/main/java/_4/TourismContest/weather/repository/WeatherForecastRepository.java
+++ b/src/main/java/_4/TourismContest/weather/repository/WeatherForecastRepository.java
@@ -18,5 +18,7 @@ public interface WeatherForecastRepository extends JpaRepository<WeatherForecast
 
     Page<WeatherForecast> findByNxAndNyAndCategoryAndFcstTimeIsAfter(int nx, int ny, String category ,LocalDateTime time, Pageable pageable);
 
+    Page<WeatherForecast> findByNxAndNyAndCategoryAndFcstTimeBetween(int nx, int ny, String category ,LocalDateTime startTime, LocalDateTime endTime, Pageable pageable);
+
     Optional<WeatherForecast> findTopByNxAndNyAndCategoryAndFcstTimeIsAfter(int nx,int ny, String category ,LocalDateTime gameTime);
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
Feat : ~
-->

##  📌 관련 이슈

- closed: #205 

## ✨ PR 세부 내용
1시간 단위 날씨 반환 API -> 경기 시작 1시간전부터 그날 23시 까지 데이터 반환하도록 수정
WeatherForecastRepostitory -> findByNxAndNyAndCategoryAndFcstTimeBetween 함수 추가
<!-- 수정/추가한 내용을 적어주세요. -->

## ⌛ 소요 시간
