### PR TITLE
[Fix] 선수픽 맛집 데이터가 4개 이하인 것에 대한 예외처리

### DIFF
--- a/src/main/java/_4/TourismContest/spot/application/SpotService.java
+++ b/src/main/java/_4/TourismContest/spot/application/SpotService.java
@@ -74,7 +74,7 @@ public class SpotService {
                 .orElseThrow(() -> new BadRequestException("잘못된 구장 정보입니다"));
         List<Spot> spots = spotRepository.findSpotsByStadiumAndCategory(stadium, SpotCategory.ATHLETE_PICK);
 
-        List<Spot> sampleSpots = new ArrayList<>();
+        List<Spot> sampleSpots;
         if(spots.size()<4){
             sampleSpots = spots;
         } else{

--- a/src/main/java/_4/TourismContest/spot/application/SpotService.java
+++ b/src/main/java/_4/TourismContest/spot/application/SpotService.java
@@ -77,6 +77,7 @@ public class SpotService {
         int pageSize = 4;
         int totalPages = spots.size() / pageSize;  //야구선수픽 전체 장소 개수
         Random random = new Random();
+
         int pageNum = random.nextInt(totalPages);
 
         List<Spot> spotsByStadiumAndCategory = spotRepository.findSpotsByStadiumAndCategory(stadium, SpotCategory.ATHLETE_PICK, PageRequest.of(pageNum, pageSize));

--- a/src/main/java/_4/TourismContest/spot/application/SpotService.java
+++ b/src/main/java/_4/TourismContest/spot/application/SpotService.java
@@ -74,15 +74,15 @@ public class SpotService {
                 .orElseThrow(() -> new BadRequestException("잘못된 구장 정보입니다"));
         List<Spot> spots = spotRepository.findSpotsByStadiumAndCategory(stadium, SpotCategory.ATHLETE_PICK);
 
-        int pageSize = 4;
-        int totalPages = spots.size() / pageSize;  //야구선수픽 전체 장소 개수
-        Random random = new Random();
+        List<Spot> sampleSpots = new ArrayList<>();
+        if(spots.size()<4){
+            sampleSpots = spots;
+        } else{
+            Collections.shuffle(spots);
+            sampleSpots = spots.subList(0, 4);
+        }
 
-        int pageNum = random.nextInt(totalPages);
-
-        List<Spot> spotsByStadiumAndCategory = spotRepository.findSpotsByStadiumAndCategory(stadium, SpotCategory.ATHLETE_PICK, PageRequest.of(pageNum, pageSize));
-
-        List<AthletePickSpot> athletePickSpotsInfo = athletePickSpotRepository.findAthletePickSpotsBySpotIn(spotsByStadiumAndCategory);
+        List<AthletePickSpot> athletePickSpotsInfo = athletePickSpotRepository.findAthletePickSpotsBySpotIn(sampleSpots);
         List<SpotBasicPreviewDto> athletePickPreviewDtoList = new ArrayList<>();
         for (AthletePickSpot info : athletePickSpotsInfo) {
             boolean isScraped = false;

--- a/src/main/java/_4/TourismContest/spot/presentation/SpotStadiumController.java
+++ b/src/main/java/_4/TourismContest/spot/presentation/SpotStadiumController.java
@@ -30,7 +30,7 @@ public class SpotStadiumController {
 
     @GetMapping("/{stadiumId}/선수맛집")
     @Operation(summary = "구장별 보기 페이지 기본 카테고리 조회" ,description = "구장, 카테고리 필터를 사용하여, 조회. 페이지 사이즈 지정하여 원하는 데이터 개수 선택 가능합니다. 토큰과 같이 보낼 시 스크랩 여부도 같이 감. 카테고리 필터 : (숙소, 맛집, 문화, 쇼핑)\n radius (검색 범위) : Km 단위 (1km) ")
-    public ResponseEntity<SpotStadiumPreviewResponse> getAthletePickSpot(@PathVariable Long stadiumId, @CurrentUser UserPrincipal userPrincipal) {
+    public ResponseEntity<SpotStadiumPreviewResponse> getAthletePickSpot(@PathVariable("stadiumId") Long stadiumId, @CurrentUser UserPrincipal userPrincipal) {
         SpotStadiumPreviewResponse spotStadiumPreviewResponse = spotService.getAthletePickSpot(stadiumId,userPrincipal);
         return new ResponseEntity<>(spotStadiumPreviewResponse, HttpStatus.OK);
     }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
Feat : ~
-->

##  📌 관련 이슈

## ✨ PR 세부 내용
- spot 리스트를 가져와서 사이즈가 4개 이하이면 그대로 반환하고, 4개 이상이면 섞고, 4개를 뽑아서 반환한다.

## ⌛ 소요 시간
